### PR TITLE
Create .gitattributes to fix language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+document/* linguist-documentation
+Makefile linguist-vendored=true


### PR DESCRIPTION
The current language statistics are taking in account the `document`
folder. This shows the project as only ~43% Python... The `.gitattributes`
file fixes this by excluding that folder and additionally the `Makefile` in
the root folder as well.